### PR TITLE
Allow go.mod deps from private repositories 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 if [ -n "${GITHUB_WORKSPACE}" ]; then
@@ -6,6 +6,12 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
 fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+
+# applying git url patches to allow the use of private repositories
+awk 'BEGIN{for(v in ENVIRON) print v}' | grep '^GIT_URL_OVERRIDE' | while read -r url_patch
+do
+ echo git config --global url."${!url_patch%%;*}".insteadOf "${!url_patch##*;}"
+done
 
 staticcheck ${INPUT_STATICCHECK_FLAGS} -f=json ${INPUT_TARGET:-.} \
   | jq -f /to-rdjsonl.jq -c \


### PR DESCRIPTION
Currently this action can't be used as soon as you have at least one go dependency which requires authentication.

Currently the only way in go to allow fetching private repositories is by adding an URL patch to your global `gitconfig` and setting the `GOPRIVATE` var.

The github action runner passes the `GOPRIVATE` variable correctly to the docker container, but the `gitconfig` of the runner has no effect on the go installation inside the container.

With this change it is now possible to apply git url patches using  an environment variables prefixed with `GIT_URL_OVERRIDE`

In our setup we use the action like this now

```yaml
  - uses: ourOrg/action-staticcheck@master
     name: Staticcheck
     env:
       GOPRIVATE: github.com/ourOrg/privateRepo
       GIT_URL_OVERRIDE: https://${{ secrets.GO_MODULE_TOKEN }}:x-oauth-basic@github.com;https://github.com
     with:
       reporter: github-pr-review
       filter_mode: nofilter
```

I also changed the `/bin/sh` to `/bin/bash` since `/bin/sh` is a link to a `bash` on most linux systems, except for ubuntu where it is a `dash` shell. So `/bin/sh` is no guarantee for what shell will be used.  (Also this change requires the bash expansion features) 
