### PR TITLE
remove the hadolint job from GitHub Actions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+
 jobs:
   shellcheck:
     name: runner / shellcheck
@@ -17,23 +18,6 @@ jobs:
           if_true: "github-pr-review"
           if_false: "github-check"
       - uses: reviewdog/action-shellcheck@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: ${{ steps.reporter.outputs.value }}
-          level: warning
-
-  hadolint:
-    name: runner / hadolint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: haya14busa/action-cond@v1
-        id: reporter
-        with:
-          cond: ${{ github.event_name == 'pull_request' }}
-          if_true: "github-pr-review"
-          if_false: "github-check"
-      - uses: reviewdog/action-hadolint@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}


### PR DESCRIPTION
The action have been migrated from a Docker action to a composite action.
https://github.com/reviewdog/action-staticcheck/pull/16
So hadolint a Dockerfile linter is no longer needed.