### PR TITLE
Add fail_level and deprecate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,25 @@ inputs:
     default: 'error'
   reporter:
     description: 'Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].'
-    default: 'github-pr-check'
+    default: 'github-pr-review'
   filter_mode:
     description: |
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
+    deprecationMessage: 'Deprecated, use `fail_level` instead.'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -13,18 +13,26 @@ inputs:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
   reporter:
-    description: 'Reporter of reviewdog command [github-check,github-pr-review].'
+    description: 'Reporter of reviewdog command [github-pr-check,github-check,github-pr-review].'
     default: 'github-pr-review'
   filter_mode:
     description: |
-      Filtering for the reviewdog command [added,diff_context,file,nofilter].
+      Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
+    deprecationMessage: 'Deprecated, use `fail_level` instead.'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''
@@ -47,6 +55,7 @@ runs:
         INPUT_GITHUB_TOKEN: '${{ inputs.github_token }}'
         INPUT_WORKDIR: '${{ inputs.workdir }}'
         INPUT_LEVEL: '${{ inputs.level }}'
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: '${{ inputs.fail_on_error }}'
         INPUT_FILTER_MODE: '${{ inputs.filter_mode }}'
         INPUT_REPORTER: '${{ inputs.reporter }}'

--- a/script.sh
+++ b/script.sh
@@ -22,6 +22,7 @@ staticcheck ${INPUT_STATICCHECK_FLAGS} -f=json ${INPUT_TARGET:-.} \
       -name="staticcheck" \
       -reporter="${INPUT_REPORTER:-github-pr-review}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
To adapt for the same change in the reviewdog 0.20.2, refer to https://github.com/reviewdog/reviewdog/pull/1854.