### PR TITLE
feat: add use_go_install flag to build staticcheck from source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,5 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
           level: info
-          target: ./testdata/
+          workdir: ./testdata
           use_go_install: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,19 @@ jobs:
           level: error
           workdir: ./testdata
           reviewdog_flags: -filter-mode=file
+
+  test-go-install:
+    name: runner / staticcheck (use_go_install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: "testdata/go.mod"
+      - uses: ./
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check
+          level: info
+          target: ./testdata/
+          use_go_install: true

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ inputs:
   staticcheck_flags:
     description: 'staticcheck flags'
     default: ''
+  use_go_install:
+    description: 'Use go install to build staticcheck from source instead of downloading prebuilt binary'
+    default: 'false'
 ```
 
 ## Usage
@@ -121,4 +124,3 @@ This repository uses [haya14busa/action-depup](https://github.com/haya14busa/act
 reviewdog version.
 
 [![reviewdog depup demo](https://user-images.githubusercontent.com/3797062/73154254-170e7500-411a-11ea-8211-912e9de7c936.png)](https://github.com/reviewdog/action-template/pull/6)
-

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,9 @@ inputs:
   staticcheck_flags:
     description: 'staticcheck flags'
     default: ''
+  use_go_install:
+    description: 'Use go install to build staticcheck from source instead of downloading prebuilt binary'
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -62,6 +65,7 @@ runs:
         INPUT_REVIEWDOG_FLAGS: '${{ inputs.reviewdog_flags }}'
         INPUT_TARGET: '${{ inputs.target }}'
         INPUT_STATICCHECK_FLAGS: '${{ inputs.staticcheck_flags }}'
+        INPUT_USE_GO_INSTALL: '${{ inputs.use_go_install }}'
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 branding:

--- a/script.sh
+++ b/script.sh
@@ -17,6 +17,7 @@ else
   curl -sfL  "https://github.com/dominikh/go-tools/releases/download/${STATICCHECK_VERSION}/staticcheck_linux_amd64.tar.gz" | tar -xvz -C "${TEMP_PATH}" --strip-components=1
 fi
 staticcheck --version
+go version -m "$(which staticcheck)"
 echo '::endgroup::'
 
 

--- a/script.sh
+++ b/script.sh
@@ -9,7 +9,13 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 STATICCHECK_VERSION="2025.1.1"
 echo '::group:: Installing staticcheck ... https://staticcheck.io'
-curl -sfL  "https://github.com/dominikh/go-tools/releases/download/${STATICCHECK_VERSION}/staticcheck_linux_amd64.tar.gz" | tar -xvz -C "${TEMP_PATH}" --strip-components=1
+if [ "${INPUT_USE_GO_INSTALL}" = "true" ]; then
+  echo "Building staticcheck from source using go install..."
+  GOBIN="${TEMP_PATH}" go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
+else
+  echo "Downloading prebuilt staticcheck binary..."
+  curl -sfL  "https://github.com/dominikh/go-tools/releases/download/${STATICCHECK_VERSION}/staticcheck_linux_amd64.tar.gz" | tar -xvz -C "${TEMP_PATH}" --strip-components=1
+fi
 staticcheck --version
 echo '::endgroup::'
 

--- a/testdata/go.mod
+++ b/testdata/go.mod
@@ -1,3 +1,3 @@
 module github.com/reviewdog/action-staticcheck/testdata
 
-go 1.22.4
+go 1.25.0


### PR DESCRIPTION
## Summary
- Add `use_go_install` flag to optionally build staticcheck from source using `go install`
- When enabled, uses `go install honnef.co/go/tools/cmd/staticcheck@<version>` instead of downloading prebuilt binaries
- Add test job to verify the new functionality works correctly

## Test plan
- [x] Added new test job `test-go-install` in GitHub Actions workflow
- [x] CI tests pass with both prebuilt binary and go install methods
- [x] Verify staticcheck runs correctly when built from source

🤖 Generated with [Claude Code](https://claude.ai/code)