### PR TITLE
[chore] Update README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
           # Report all results.
           filter_mode: nofilter
           # Exit with 1 when it find at least one finding.
-          fail_on_error: true
+          fail_level: error
 ```
 
 ## Development


### PR DESCRIPTION
`fail_on_error` was deprecated in v.125.0. You should use `fail_level` instead.

https://github.com/reviewdog/action-staticcheck/releases/tag/v1.25.0